### PR TITLE
[02-resources] fixed is_prime function

### DIFF
--- a/resources/isprime.c
+++ b/resources/isprime.c
@@ -25,7 +25,7 @@ int is_prime(unsigned n) {
   unsigned j;
   if (n < 2)
     return 0;
-  for (j = 2; j * j < n; ++j)
+  for (j = 2; j * j <= n; ++j)
     if ((n % j) == 0)
       return 0;
   return 1;


### PR DESCRIPTION
The function `int is_prime(unsigned n)` in _02-resources/isprime.c_  is incorrect: the result for input "4" is 1, so it means that 4 is a prime number. It is caused with condition in the "for" loop: `j * j < n` -> `j * j <= n`.