### PR TITLE
Fix bug with GCD

### DIFF
--- a/basics/euclid-div.c
+++ b/basics/euclid-div.c
@@ -33,7 +33,7 @@ int gcd(int x, int y) {
   assert(y != 0);
   q = eu_mod(x, y);
   if (q == 0)
-    return y;
+    return iabs(y);
   return gcd(y, q);
 }
 


### PR DESCRIPTION
Bug:
  The result value is less than zero when abs value of second input is GCD and value is less than zero.
Example:
  Input: 18 -3
  Result: -3