### PR TITLE
fix: mismatch between number of expected args for testing program

### DIFF
--- a/coursework/contests/hwasm/statements/problem_agf_begin.c
+++ b/coursework/contests/hwasm/statements/problem_agf_begin.c
@@ -4,7 +4,8 @@ int foo(int x, int y);
 
 int main() {
   int x, y, z;
-  scanf("%d%d", &x, &y);
+  scanf("%d", &x);
+  y = 0;
   z = foo(x, y);
   printf("%d\n", z);
 }


### PR DESCRIPTION
In a previous version of problem_agf_begin.c, the program was expected to take a pair of arguments (x and y) from test files for problem_agf, but all test cases contained only one (x).

As I figured out, all tests cases rely on the assumption that if (x < 0) => y = 0, then x >= 0, value of y doesn't matter.

Now y is set to a fixed value, according to the assumption above.