### PR TITLE
fix: typo in problem description

### DIFF
--- a/coursework/contests/hwasm/statements/problem_rp.html
+++ b/coursework/contests/hwasm/statements/problem_rp.html
@@ -11,7 +11,7 @@
 <br/>
 <p>Пример:</p>
 <p>Вход: -1 3</p>
-<p>Выход: 0x7d 0x2aaaab 0x7d 0x2aaaac</p>
+<p>Выход: 0x7d 0x2aaaab 0x7d 0x2aaaaa</p>
 <br/>
 <p>Пример:</p>
 <p>Вход: 1 2</p>


### PR DESCRIPTION
Testcase 002.ans doesn't match the example in the description. Assume the testcase as the source of truth.