### PR TITLE
hwasm problem ap : incomplete statement

### DIFF
--- a/coursework/contests/hwasm/statements/problem_ap.html
+++ b/coursework/contests/hwasm/statements/problem_ap.html
@@ -12,6 +12,9 @@ table, th, td {
 <pre>
 // --- on entry edi = x (unsigned) ---
 // --- returns 1 if prime, 0 if composite ---
+  .intel_syntax noprefix
+  .globl start
+
 start:
 	mov	eax, 0
 	cmp	edi, 1


### PR DESCRIPTION
problem `ap` in assembly homeworks has incomplete initial setting.

Otherwise compilation log 

```
stdout:
cp /temp/compiling/source.cpp func.s
gcc -c main.c func.s


stderr:
func.s: Assembler messages:
func.s:5: Error: operand size mismatch for `mov'
func.s:6: Error: operand size mismatch for `cmp'
func.s:8: Error: operand size mismatch for `cmp'
...
```